### PR TITLE
4-2 Done -> Add Category&add an implementation to store an item

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Build@Mercari Training Program 
 
-This is @<your github id>'s build training repository.
+This is @kawauso-luv's build training repository.
 
 Build trainingの前半では個人で課題に取り組んでもらい、Web開発の基礎知識をつけていただきます。
 ドキュメントには詳細なやり方は記載しません。自身で検索したり、リファレンスを確認したり、チームメイトと協力して各課題をクリアしましょう。

--- a/go/app/infra.go
+++ b/go/app/infra.go
@@ -39,8 +39,8 @@ func NewItemRepository() ItemRepository {
 // Insert inserts an item into the repository.
 func (i *itemRepository) Insert(ctx context.Context, item *Item) error {
 	// STEP 4-2: add an implementation to store an item
-	filePath := "../go/items.json"
-	file, err := os.OpenFile(filePath, os.O_RDWR, 0644)
+	//i *itemRepositoryとなっているのでfilepathはそのままi.fileNameで引っ張ってこれる
+	file, err := os.OpenFile(i.fileName, os.O_RDWR, 0644)
 	if err != nil {
 		return err
 	}

--- a/go/app/infra.go
+++ b/go/app/infra.go
@@ -3,6 +3,8 @@ package app
 import (
 	"context"
 	"errors"
+	"encoding/json"
+	"os"
 	// STEP 5-1: uncomment this line
 	// _ "github.com/mattn/go-sqlite3"
 )
@@ -36,7 +38,28 @@ func NewItemRepository() ItemRepository {
 
 // Insert inserts an item into the repository.
 func (i *itemRepository) Insert(ctx context.Context, item *Item) error {
-	// STEP 4-1: add an implementation to store an item
+	// STEP 4-2: add an implementation to store an item
+	filePath := "../go/items.json"
+	file, err := os.OpenFile(filePath, os.O_RDWR, 0644)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	
+	// itemをJSONにエンコード
+	itemData, err := json.Marshal(item)
+	if err != nil {
+		return err
+	}
+
+	// ファイルに書き込む
+	_, err = file.Write(itemData)
+	if err != nil {
+		return err
+	}
+
+	// レスポンスを返す
+	// w.Write([]byte("Item saved successfully"))
 
 	return nil
 }

--- a/go/app/infra.go
+++ b/go/app/infra.go
@@ -12,6 +12,7 @@ var errImageNotFound = errors.New("image not found")
 type Item struct {
 	ID   int    `db:"id" json:"-"`
 	Name string `db:"name" json:"name"`
+	Category string `db:"category" json:"category"`
 }
 
 // Please run `go generate ./...` to generate the mock implementation

--- a/go/app/server.go
+++ b/go/app/server.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"image"
+	// "image"
 )
 
 type Server struct {
@@ -43,6 +43,7 @@ func (s Server) Run() int {
 	// set up routes
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /", h.Hello)
+	mux.HandleFunc("GET /items", h.GetItem)
 	mux.HandleFunc("POST /items", h.AddItem)
 	mux.HandleFunc("GET /images/{filename}", h.GetImage)
 
@@ -69,6 +70,17 @@ type HelloResponse struct {
 
 // Hello is a handler to return a Hello, world! message for GET / .
 func (s *Handlers) Hello(w http.ResponseWriter, r *http.Request) {
+	resp := HelloResponse{Message: "Hello, world!"}
+	err := json.NewEncoder(w).Encode(resp)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+//4-3
+// GetItem is a handler to return a itemdata for GET /items 
+func (s *Handlers) GetItem(w http.ResponseWriter, r *http.Request) {
 	resp := HelloResponse{Message: "Hello, world!"}
 	err := json.NewEncoder(w).Encode(resp)
 	if err != nil {
@@ -133,32 +145,6 @@ func (s *Handlers) AddItem(w http.ResponseWriter, r *http.Request) {
 	}
 	message := fmt.Sprintf("item received: %s", item.Name)
 	slog.Info(message)
-
-	// STEP 4-2: add an implementation to store an item //<- Now //imageはitemの間違いだったらしい
-	filePath := "../data/items.json"
-	file, err := os.OpenFile(filePath, os.O_RDWR, 0644)
-	if err != nil {
-		http.Error(w, "Failed to open file", http.StatusInternalServerError)
-		return
-	}
-	defer file.Close()
-	
-	// itemをJSONにエンコード
-	itemData, err := json.Marshal(item)
-	if err != nil {
-		http.Error(w, "Failed to marshal item to JSON", http.StatusInternalServerError)
-		return
-	}
-
-	// ファイルに書き込む
-	_, err = file.Write(itemData)
-	if err != nil {
-		http.Error(w, "Failed to write item to file", http.StatusInternalServerError)
-		return
-	}
-
-	// レスポンスを返す
-	w.Write([]byte("Item saved successfully"))
 
 
 	err = s.itemRepo.Insert(ctx, item)

--- a/go/app/server.go
+++ b/go/app/server.go
@@ -78,16 +78,7 @@ func (s *Handlers) Hello(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-//4-3
-// GetItem is a handler to return a itemdata for GET /items 
-func (s *Handlers) GetItem(w http.ResponseWriter, r *http.Request) {
-	resp := HelloResponse{Message: "Hello, world!"}
-	err := json.NewEncoder(w).Encode(resp)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-}
+
 
 type AddItemRequest struct {
 	Name string `form:"name"`

--- a/go/app/server.go
+++ b/go/app/server.go
@@ -134,8 +134,31 @@ func (s *Handlers) AddItem(w http.ResponseWriter, r *http.Request) {
 	message := fmt.Sprintf("item received: %s", item.Name)
 	slog.Info(message)
 
-	// STEP 4-2: add an implementation to store an image //<- Now //4-4（上のコード）と何が違うか聞く
+	// STEP 4-2: add an implementation to store an item //<- Now //imageはitemの間違いだったらしい
+	filePath := "../data/items.json"
+	file, err := os.OpenFile(filePath, os.O_RDWR, 0644)
+	if err != nil {
+		http.Error(w, "Failed to open file", http.StatusInternalServerError)
+		return
+	}
+	defer file.Close()
 	
+	// itemをJSONにエンコード
+	itemData, err := json.Marshal(item)
+	if err != nil {
+		http.Error(w, "Failed to marshal item to JSON", http.StatusInternalServerError)
+		return
+	}
+
+	// ファイルに書き込む
+	_, err = file.Write(itemData)
+	if err != nil {
+		http.Error(w, "Failed to write item to file", http.StatusInternalServerError)
+		return
+	}
+
+	// レスポンスを返す
+	w.Write([]byte("Item saved successfully"))
 
 
 	err = s.itemRepo.Insert(ctx, item)

--- a/go/app/server.go
+++ b/go/app/server.go
@@ -15,14 +15,14 @@ import (
 type Server struct {
 	// Port is the port number to listen on.
 	Port string
-	// ImageDirPath is the path to the directory storing images.
+	// ImageDirPath is the path to the directory storing images. //画像パス保存
 	ImageDirPath string
 }
 
-// Run is a method to start the server.
+// Run is a method to start the server. //Run→サーバーをスタート。戻り値0なら成功、1なら失敗
 // This method returns 0 if the server started successfully, and 1 otherwise.
 func (s Server) Run() int {
-	// set up logger
+	// set up logger //ログの設定
 	logger := slog.New(slog.NewJSONHandler(os.Stderr, nil))
 	slog.SetDefault(logger)
 	// STEP 4-6: set the log level to DEBUG
@@ -80,7 +80,7 @@ func (s *Handlers) Hello(w http.ResponseWriter, r *http.Request) {
 type AddItemRequest struct {
 	Name string `form:"name"`
 	Category string `form:"category"` // STEP 4-2: add a category field //<-Done
-	Image []byte `form:"image"` // STEP 4-4: add an image field
+	Image []byte `form:"image"` // STEP 4-4: add an image field //画像はbyteに変換して保存する
 }
 
 type AddItemResponse struct {
@@ -91,7 +91,7 @@ type AddItemResponse struct {
 func parseAddItemRequest(r *http.Request) (*AddItemRequest, error) {
 	req := &AddItemRequest{
 		Name: r.FormValue("name"),
-		Category: r.FormValue("category") // STEP 4-2: add a category field // <- Done
+		Category: r.FormValue("category"), // STEP 4-2: add a category field // <- Done
 	}
 
 	// STEP 4-4: add an image field
@@ -134,7 +134,7 @@ func (s *Handlers) AddItem(w http.ResponseWriter, r *http.Request) {
 	message := fmt.Sprintf("item received: %s", item.Name)
 	slog.Info(message)
 
-	// STEP 4-2: add an implementation to store an image //<- Now
+	// STEP 4-2: add an implementation to store an image //<- Now //4-4（上のコード）と何が違うか聞く
 	
 
 

--- a/go/app/server.go
+++ b/go/app/server.go
@@ -78,7 +78,16 @@ func (s *Handlers) Hello(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-
+//4-3
+// GetItem is a handler to return a itemdata for GET /items 
+func (s *Handlers) GetItem(w http.ResponseWriter, r *http.Request) {
+	resp := HelloResponse{Message: "Hello, world!"}
+	err := json.NewEncoder(w).Encode(resp)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
 
 type AddItemRequest struct {
 	Name string `form:"name"`

--- a/go/app/server.go
+++ b/go/app/server.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"image"
 )
 
 type Server struct {
@@ -78,7 +79,7 @@ func (s *Handlers) Hello(w http.ResponseWriter, r *http.Request) {
 
 type AddItemRequest struct {
 	Name string `form:"name"`
-	// Category string `form:"category"` // STEP 4-2: add a category field
+	Category string `form:"category"` // STEP 4-2: add a category field //<-Done
 	Image []byte `form:"image"` // STEP 4-4: add an image field
 }
 
@@ -90,7 +91,7 @@ type AddItemResponse struct {
 func parseAddItemRequest(r *http.Request) (*AddItemRequest, error) {
 	req := &AddItemRequest{
 		Name: r.FormValue("name"),
-		// STEP 4-2: add a category field
+		Category: r.FormValue("category") // STEP 4-2: add a category field // <- Done
 	}
 
 	// STEP 4-4: add an image field
@@ -100,7 +101,9 @@ func parseAddItemRequest(r *http.Request) (*AddItemRequest, error) {
 		return nil, errors.New("name is required")
 	}
 
-	// STEP 4-2: validate the category field
+	if req.Category == "" { // STEP 4-2: validate the category field //<- Done
+		return nil, errors.New("category is required")
+	} 
 	// STEP 4-4: validate the image field
 	return req, nil
 }
@@ -125,13 +128,16 @@ func (s *Handlers) AddItem(w http.ResponseWriter, r *http.Request) {
 
 	item := &Item{
 		Name: req.Name,
-		// STEP 4-2: add a category field
+		Category: req.Category, // STEP 4-2: add a category field //<-Done
 		// STEP 4-4: add an image field
 	}
 	message := fmt.Sprintf("item received: %s", item.Name)
 	slog.Info(message)
 
-	// STEP 4-2: add an implementation to store an image
+	// STEP 4-2: add an implementation to store an image //<- Now
+	
+
+
 	err = s.itemRepo.Insert(ctx, item)
 	if err != nil {
 		slog.Error("failed to store item: ", "error", err)


### PR DESCRIPTION
一応指定されたものは完了したと思うのですが、エラーハンドリングが適切でない気がしているので、方法を教えていただければ幸いです。その他にもアドバイスや改善点がありましたらドシドシ教えてください。

＜4-2課題＞
・本節のゴールは、 POST /items のエンドポイントの拡張と items に関連するデータの永続化です。
・items.json というファイルを作り、ファイル内で保持されるJSONではitemsというキーに新しく登録された商品を追加するようにしましょう。

＜DONE:4-2＞
・Add "Category" to server.go & infra.go
・Add implementation to store an item->“name” and “category” are properly stored in the json file(items.json).